### PR TITLE
use Unified Dyes on_dig where needed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,6 +59,7 @@ minetest.register_node("stained_glass:stained_glass", {
 	groups = {snappy=2,cracky=3,oddly_breakable_by_hand=3, not_in_creative_inventory=1, ud_param2_colorable = 1},
 	sounds = default.node_sound_glass_defaults(),
 	on_construct = unifieddyes.on_construct,
+	on_dig = unifieddyes.on_dig,
 })
 
 minetest.override_item("moreblocks:super_glow_glass", {
@@ -84,6 +85,7 @@ minetest.register_node("stained_glass:stained_trap_glass", {
 	groups = {snappy=2,cracky=3,oddly_breakable_by_hand=3, not_in_creative_inventory=1, ud_param2_colorable = 1},
 	sounds = default.node_sound_glass_defaults(),
 	on_construct = unifieddyes.on_construct,
+	on_dig = unifieddyes.on_dig,
 })
 
 minetest.override_item("moreblocks:trap_super_glow_glass", {


### PR DESCRIPTION
prevents creating look-alike/excess itemstacks on-dig of a colored item
requires UD commit 9ff40a7f or later